### PR TITLE
fix: remove duplicate conditional statement

### DIFF
--- a/src/useNextSanityImage.ts
+++ b/src/useNextSanityImage.ts
@@ -39,10 +39,6 @@ function getSanityRefId(image: SanityImageSource): string {
 	const ref = image as SanityReference;
 	const img = image as SanityAsset;
 
-	if (typeof image === 'string') {
-		return image;
-	}
-
 	if (obj.asset) {
 		return obj.asset._ref || (obj.asset as SanityAsset)._id;
 	}


### PR DESCRIPTION
This conditional early return is already in place on the first line of the `getSanityRefId` function (L34).