### PR TITLE
Allow useNextSanityImage to receive a client or a config

### DIFF
--- a/src/useNextSanityImage.ts
+++ b/src/useNextSanityImage.ts
@@ -1,9 +1,11 @@
 import imageUrlBuilder from '@sanity/image-url';
 import {
 	SanityAsset,
+	SanityClientLike,
 	SanityImageObject,
 	SanityImageSource,
 	SanityModernClientLike,
+	SanityProjectDetails,
 	SanityReference
 } from '@sanity/image-url/lib/types/types';
 import { ImageLoader } from 'next/image';
@@ -76,26 +78,31 @@ export function getCroppedDimensions(
 	};
 }
 
+type SanityClientOrProjectDetails =
+	| SanityClientLike
+	| SanityProjectDetails
+	| SanityModernClientLike;
+
 export function useNextSanityImage(
-	sanityClient: SanityModernClientLike,
+	sanityClient: SanityClientOrProjectDetails,
 	image: SanityImageSource,
 	options?: UseNextSanityImageOptions
 ): UseNextSanityImageProps;
 
 export function useNextSanityImage(
-	sanityClient: SanityModernClientLike,
+	sanityClient: SanityClientOrProjectDetails,
 	image: null,
 	options?: UseNextSanityImageOptions
 ): null;
 
 export function useNextSanityImage(
-	sanityClient: SanityModernClientLike,
+	sanityClient: SanityClientOrProjectDetails,
 	image: SanityImageSource | null,
 	options?: UseNextSanityImageOptions
 ): UseNextSanityImageProps | null;
 
 export function useNextSanityImage(
-	sanityClient: SanityModernClientLike,
+	sanityClient: SanityClientOrProjectDetails,
 	image: SanityImageSource | null,
 	options?: UseNextSanityImageOptions
 ): UseNextSanityImageProps | null {

--- a/test/useNextSanityImage.test.ts
+++ b/test/useNextSanityImage.test.ts
@@ -33,12 +33,13 @@ const DEFAULT_HOTSPOT = {
 	height: 1
 };
 
-const configuredSanityClient = createClient({
+const sanityClientConfig = {
 	projectId: PROJECT_ID,
 	dataset: DATASET,
 	useCdn: true,
 	apiVersion: '2021-10-21'
-});
+};
+const configuredSanityClient = createClient(sanityClientConfig);
 
 const generateSanityImageSource = (width: number, height: number) => ({
 	asset: {
@@ -191,5 +192,19 @@ describe('useNextSanityImage', () => {
 		const { result } = renderHook(() => useNextSanityImage(configuredSanityClient, null));
 
 		expect(result.current).toBeNull();
+	});
+
+	test('useNextSanityImage can be used with a client configuration instead of an instantiated client', () => {
+		const image = generateSanityImageSource(DEFAULT_IMAGE_WIDTH, DEFAULT_IMAGE_HEIGHT);
+		const { result } = renderHook(() => useNextSanityImage(sanityClientConfig, image));
+
+		const expectedWidth = DEFAULT_IMAGE_WIDTH;
+
+		expect(result.current).toEqual({
+			loader: expect.any(Function),
+			src: generateSanityImageUrl(`?q=75&fit=clip&auto=format`),
+			width: expectedWidth,
+			height: Math.round(expectedWidth / DEFAULT_IMAGE_ASPECT_RATIO)
+		});
 	});
 });


### PR DESCRIPTION
This brings the type in line with `@sanity/image-url`, which accepts a plain config, or either type of client (from which it then extracts the config).

https://github.com/sanity-io/image-url/blob/v1.0.2/src/builder.ts#L44-L46

I noticed that the type was flip-flopping a bit when upgrading between `next-sanity-image` 4.0 → 5.0 → 6.0. This should hopefully stabilize it, so that people upgrading can keep passing whichever client argument they already have in place. :)

Related:
* #53
* #54