### PR TITLE
Remove "images.domain" installation requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,6 @@ This library also expects you to pass in a [SanityClient instance](https://www.n
 npm install --save @sanity/client
 ```
 
-Finally configure your next.config.js to allow loading images from the Sanity.io CDN
-
-```javascript
-// next.config.js
-module.exports = {
-	images: {
-		domains: ['cdn.sanity.io']
-	}
-};
-```
-
 ## Upgrading
 
 ### Upgrading from 4.x.x to 5.x.x


### PR DESCRIPTION
You are not required to set:

```js
// next.config.js
module.exports = {
	images: {
		domains: ['cdn.sanity.io']
	}
};
```

This is only required if you are using the default loader, which this plugin is not.