### PR TITLE
Send "original" URL as src attribute

### DIFF
--- a/src/useNextSanityImage.ts
+++ b/src/useNextSanityImage.ts
@@ -113,12 +113,13 @@ export function useNextSanityImage(
 			return null;
 		}
 
+		const src = imageUrlBuilder(sanityClient).image(image);
 		const originalImageDimensions = getImageDimensions(id);
 		const croppedImageDimensions = getCroppedDimensions(image, originalImageDimensions);
 
 		const loader: ImageLoader = ({ width, quality }) => {
 			return (
-				imageBuilder(imageUrlBuilder(sanityClient).image(image).auto('format'), {
+				imageBuilder(src.auto('format'), {
 					width,
 					originalImageDimensions,
 					croppedImageDimensions,
@@ -127,15 +128,12 @@ export function useNextSanityImage(
 			);
 		};
 
-		const baseImgBuilderInstance = imageBuilder(
-			imageUrlBuilder(sanityClient).image(image).auto('format'),
-			{
-				width: null,
-				originalImageDimensions,
-				croppedImageDimensions,
-				quality: null
-			}
-		);
+		const baseImgBuilderInstance = imageBuilder(src.auto('format'), {
+			width: null,
+			originalImageDimensions,
+			croppedImageDimensions,
+			quality: null
+		});
 
 		const width =
 			baseImgBuilderInstance.options.width ||
@@ -151,7 +149,7 @@ export function useNextSanityImage(
 
 		return {
 			loader,
-			src: baseImgBuilderInstance.url() as string,
+			src: src.url(),
 			width,
 			height
 		};


### PR DESCRIPTION
Resolves https://github.com/lorenzodejong/next-sanity-image/issues/50

Next.js sends an [error](https://github.com/vercel/next.js/blob/00ed837bb4b71ce0c30256e4d07638225b31a7e5/packages/next/src/shared/lib/get-img-props.ts#L541) if `src` is the same as the optimized image.

In this case, we sent the optimized src attribute back to the  `getImgProps` function